### PR TITLE
DPC-810 fix: use `prod` for prod url

### DIFF
--- a/assets/downloads/jwt.html
+++ b/assets/downloads/jwt.html
@@ -21,7 +21,7 @@
       var data = {
         "iss": clientToken,
         "sub": clientToken,
-        "aud": "https://" + env + "dpc.cms.gov/api/v1/Token/auth",
+        "aud": "https://" + env + ".dpc.cms.gov/api/v1/Token/auth",
         "exp": Math.round(new Date().getTime() / 1000) + 300,
         "iat": Math.round(Date.now()),
         "jti": uuid,
@@ -330,8 +330,8 @@
           </div>
         </div>
         <select name="env-select" id="env" style="width:800px;">
-          <option value="sandbox.">Sandbox</option>
-          <option value="">Production</option>
+          <option value="sandbox">Sandbox</option>
+          <option value="prod">Production</option>
         </select>
       </div>
       


### PR DESCRIPTION
### Fixes [DPC-810](https://jiraent.cms.gov/browse/DPC-810)

The url for `prod` actually needs to include `prod`.

### Proposed Changes

- add `prod` value to select
- move the `.` to the url when being concatenated

### Change Details



### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

No concerns

### Acceptance Validation


### Feedback Requested

Any
