### PR TITLE
Implement Tagging and CI/CD for Static Site

### DIFF
--- a/ops/Jenkinsfile.continuous_delivery
+++ b/ops/Jenkinsfile.continuous_delivery
@@ -1,0 +1,62 @@
+def github_creds = 'jenkins-github-token'
+DEPLOY = 'Do Not Deploy'
+
+pipeline {
+  options {
+    disableConcurrentBuilds()
+  }
+
+  agent {
+    node {
+      label ''
+      customWorkspace 'workspace/dpc-static-site-continuous-delivery'
+    }
+  }
+
+  triggers {
+    pollSCM('H/2 * * * *')
+  }
+
+  stages {
+
+    stage('Clear the working dir') {
+      steps {
+        script {
+          dir(env.WORKSPACE) {
+            sh  """
+              # Since Docker daemon runs as root, it is likely that some root-owned artifacts will exist in each workspace
+              # Deleting the workspace as root to ensure with confidence that all artifacts are removed
+              docker exec --user root -w $WORKSPACE jenkins bash -c 'rm -fr *'
+                """
+          }
+        }
+      }
+    }
+
+    stage('Checkout dpc-static-site') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: [[name: "${env.BRANCH_NAME}"]],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'dpc-static-site']],
+          userRemoteConfigs: [[url: 'https://github.com/CMSgov/dpc-static-site.git', credentialsId: github_creds]]
+        ])
+        script {
+            if (env.BRANCH_NAME == "master") {
+                DEPLOY='stage'
+            }
+        } 
+      }
+    }
+
+    stage('Deploy Static Site') {
+      steps {
+        build job: 'DPC - Deploy - Static Site',
+        parameters: [string(name: 'DPC_STATIC_SITE_BRANCH', value: "${env.BRANCH_NAME}"), string(name: 'ENV', value: "${DEPLOY}")],
+        wait: true,
+        propagate: true
+      }
+    }
+  }
+}

--- a/ops/github_release.py
+++ b/ops/github_release.py
@@ -1,0 +1,60 @@
+import argparse
+import json
+import os
+import sys
+import urllib.request
+
+
+def main(release, release_file, repo):
+    access_token = os.environ['GITHUB_ACCESS_TOKEN']
+
+    with open(release_file, 'r') as f:
+        data = {
+            "tag_name": release,
+            "name": release,
+            "body": f.read(),
+            "draft": False,
+            "prerelease": False
+        }
+
+        base_url = "https://api.github.com"
+        path = repo
+        headers = {
+            "Authorization": "token %s" % access_token
+        }
+
+        req = urllib.request.Request(
+            base_url + path, data=json.dumps(data).encode('utf-8'),
+            headers=headers,
+            method='POST'
+        )
+        resp = urllib.request.urlopen(req)
+
+    if resp.status != 201:
+        print("Could not create release: %s" % release)
+        sys.exit(1)
+    else:
+        print("Successfully created release: %s" % release)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--release', dest='release', type=str,
+        help='The version tag/identifier for the release'
+    )
+
+    parser.add_argument(
+        '--release-file', dest='release_file', type=str,
+        help='Path to file with body of release notes'
+    )
+ 
+    parser.add_argument(
+        '--repo', dest='repo', type=str,
+        help='The repository of the release (i.e., /repos/CMSgov/dpc-static-site/releases)'
+    )
+
+    args = parser.parse_args()
+
+    main(args.release, args.release_file, args.repo)

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+PROJECT_NAME="Data at the Point of Care API Static Site"
+
+usage() {
+    cat <<EOF >&2
+Start a new $PROJECT_NAME release.
+
+Usage: GITHUB_REPO_PATH=<gh_repo> GITHUB_ACCESS_TOKEN=<gh_access_token> $(basename "$0") [-ch] [-t previous-tag new-tag]
+
+Optionally, GITHUB_USER, GITHUB_EMAIL, and GITHUB_GPG_KEY_FILE environment variables can be set prior to running this script, to identify and verify who is creating the release.  This is primarily necessary when the release process is run from a Docker container (i.e., from Jenkins).
+
+Options:
+  -h    print this help text and exit
+  -t    manually specify tags
+EOF
+}
+
+MANUAL_TAGS=
+while getopts ":chtp" opt; do
+    case "$opt" in
+        t)
+            MANUAL_TAGS=1
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+if [ $# -lt 2 ] && [ -n "$MANUAL_TAGS" ]
+then
+  usage
+  exit 1
+fi
+
+if [ -z "$(echo $(python -V) | grep "Python 3")" ]
+then
+  echo "Python 3+ is required"
+  exit 1
+fi
+
+if [ -z "$GITHUB_ACCESS_TOKEN" ]
+then
+  echo "Please export GITHUB_ACCESS_TOKEN to continue">&2
+  exit 1
+fi
+
+if [ -z "$GITHUB_REPO_PATH" ]
+then
+  echo "Please export GITHUB_REPO_PATH to continue (i.e., /CMSgov/dpc-static-site">&2
+  exit 1
+fi
+
+# initialize git configuration if env vars are set
+if [ ! -z "$GITHUB_USER" ] && [ ! -z "$GITHUB_EMAIL" ] && [ ! -z "$GITHUB_GPG_KEY_FILE" ]
+then
+  git config user.name "$GITHUB_USER"
+  git config user.email "$GITHUB_EMAIL"
+  gpg --import $GITHUB_GPG_KEY_FILE
+fi
+
+# fetch tags before any tag lookups so we have the most up-to-date list
+# and generate the correct next release number
+git fetch https://${GITHUB_ACCESS_TOKEN}@github.com$GITHUB_REPO_PATH --tags
+
+if [ -n "$MANUAL_TAGS" ]; then
+  PREVTAG="$1"
+  NEWTAG="$2"
+  PREVRELEASENUM=${PREVTAG//^r/}
+  NEWRELEASENUM=${NEWTAG//^r/}
+else
+  PREVTAG=$(git tag | sort -n | tail -1)
+  if [ ! -n "$PREVTAG" ]; then
+      PREVRELEASENUM=
+  else
+      PREVRELEASENUM=$(git tag | grep '^r[0-9]' | sed 's/^r//' | sort -n | tail -1)
+  fi
+  NEWRELEASENUM=$(($PREVRELEASENUM + 1))
+  PREVTAG="r$PREVRELEASENUM"
+  NEWTAG="r$NEWRELEASENUM"
+fi
+
+TMPFILE=$(mktemp /tmp/$(basename $0).XXXXXX) || exit 1
+
+if [ -n $PREVTAG ]
+then
+  commits=$(git log --pretty=format:"- %s" $PREVTAG..HEAD)
+else
+  commits=$(git log --pretty=format:"- %s" HEAD)
+fi
+
+echo "$NEWTAG - $(date +%Y-%m-%d)" > $TMPFILE
+echo "================" >> $TMPFILE
+echo "" >> $TMPFILE
+echo "$commits" >> $TMPFILE
+echo "" >> $TMPFILE
+
+git tag -a -m"$PROJECT_NAME release $NEWTAG" -s "$NEWTAG"
+
+RELEASE_PATH="/repos$GITHUB_REPO_PATH/releases"
+python github_release.py --release $NEWTAG --release-file $TMPFILE --repo $RELEASE_PATH
+
+rm $TMPFILE
+
+echo "Release $NEWTAG created."
+echo


### PR DESCRIPTION
In preparation for separating the DPC Static Site from the DPC API, we need a tag/release/deployment strategy.  

### Change Details

- Added scripts to be used in tagging/releasing (via Github) the static site.
- Added a Jenkins job for tagging/releasing (via Github) the static site (which make use of the scripts referenced above) as part of https://github.com/CMSgov/dpc-ops/pull/261
- Added a Jenkins job to handle CI/CD to the `stage` environment (in Akamai NetStorage) on merge to `master`
- Added a Jenkins job to deploy to Akamai NetStorage as part of https://github.com/CMSgov/dpc-ops/pull/261
- Updated Jenkins image to include `rsync`, which is used to push the static site to Akamai NetStorage as part of https://github.com/CMSgov/dpc-ops/pull/261

Note: all scripts follow the same pattern that is used on BCDA.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [x] security checklist is completed for this change
> The SIA can be viewed [here](https://confluence.cms.gov/display/DAPC/DPC+Static+Site+SIA).
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

Ran a successful tag/release execution from the Jenkins job [here](https://management.dpc.cms.gov/job/DPC%20-%20Tag%20Release%20Version%20-%20Static%20Site/8/console).

The tag/release can be viewed in Github below (I have since deleted the temporary tags):

<img width="1135" alt="Screen Shot 2020-11-09 at 4 22 48 PM" src="https://user-images.githubusercontent.com/37818548/98601480-1c097300-22ad-11eb-89eb-eac66a983619.png">

Ran a successful deployment from the Jenkins job [here](https://management.dpc.cms.gov/job/DPC%20-%20Deploy%20-%20Static%20Site/9/console).

The artifacts can be viewed on NetStorage, as seen in the screenshot below:

<img width="320" alt="Screen Shot 2020-11-09 at 4 20 32 PM" src="https://user-images.githubusercontent.com/37818548/98602059-ddc08380-22ad-11eb-8161-0bdf23ce13c2.png">

<img width="401" alt="Screen Shot 2020-11-11 at 8 41 08 AM" src="https://user-images.githubusercontent.com/37818548/98818545-b70f6380-23f9-11eb-8896-47f20a3bdfe0.png">



### Feedback Requested

Please review.
