### PR TITLE
Fix static site continuous delivery

### DIFF
--- a/ops/Jenkinsfile.continuous_delivery
+++ b/ops/Jenkinsfile.continuous_delivery
@@ -37,23 +37,18 @@ pipeline {
       steps {
         checkout([
           $class: 'GitSCM',
-          branches: [[name: "${env.BRANCH_NAME}"]],
+          branches: [[name: "master"]],
           doGenerateSubmoduleConfigurations: false,
           extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'dpc-static-site']],
           userRemoteConfigs: [[url: 'https://github.com/CMSgov/dpc-static-site.git', credentialsId: github_creds]]
         ])
-        script {
-            if (env.BRANCH_NAME == "master") {
-                DEPLOY='stage'
-            }
-        } 
       }
     }
 
     stage('Deploy Static Site') {
       steps {
         build job: 'DPC - Deploy - Static Site',
-        parameters: [string(name: 'DPC_STATIC_SITE_BRANCH', value: "${env.BRANCH_NAME}"), string(name: 'ENV', value: "${DEPLOY}")],
+        parameters: [string(name: 'DPC_STATIC_SITE_BRANCH', value: "master"), string(name: 'ENV', value: "stage")],
         wait: true,
         propagate: true
       }


### PR DESCRIPTION


### Related to [DPC-199](https://jiraent.cms.gov/browse/DPC-199)

The DPC Static Site continuous delivery job should be based only on polling `master`, but our job was erroneously polling based on an env var that was never being set.


### Change Details

- Updated the continuous delivery polling for `dpc-static-site` to align with the continuous delivery configuration for `dpc-app` and `dpc-ops`

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Executed in Jenkins [here](https://management.dpc.cms.gov/job/DPC%20-%20Static%20Site%20Continuous%20Delivery/4/).

### Feedback Requested

Please review.
