### PR TITLE
DPC-1269: correct semantic html nesting on user guide

### DIFF
--- a/common/guide.md
+++ b/common/guide.md
@@ -1662,7 +1662,7 @@ The Prefer header is NOT required for /Patient/{id}/$everything, but it DOES req
 
 ## Requesting data using _since with the /Group endpoint
 
-#### Request to Start a job using the _since parameter within the /Group endpoint
+### Request to Start a job using the _since parameter within the /Group endpoint
 
 <pre class="highlight"><code>GET /api/v1/Group/<span style="color: #045E87;">{id}</span>/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00
 </code></pre>
@@ -1691,7 +1691,7 @@ If the request was successful, a 202 Accepted response code will be returned and
 
 ## Requesting data using _since with the /Patient endpoint
 
-#### Request data synchronously for an individual Patient  using the _since parameter within the /Patient/{id}/$everything endpoint
+### Request data synchronously for an individual Patient using the _since parameter within the /Patient/{id}/$everything endpoint
 
 <pre class="highlight"><code>GET /api/v1/Patient/<span style="color: #045E87;">{id}</span>/$everything?_since=2020-02-13T08:00:00.000-05:00
 </code></pre>


### PR DESCRIPTION
### Fixes [DPC-1269](https://jira.cms.gov/browse/DPC-1269)

An automated 508 compliance scan of the DPC site found two instances of an error in the content structure, where an <h4> tag was nested in an <h2> tag without an intervening <h3>.

### Proposed Changes

* Move rogue <h4> tags up to be <h3> tags.

### Change Details

Lines 1665 and 1694 on guide.md have been changed from <h4> to <h3> tags. 

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

The user guide no longer skips heading levels.

### Feedback Requested

Confirm that the page now nests properly.
Let me know how to run another 508 scan to confirm we've fixed the error.
