### PR TITLE
DPC-1373: Add information on specifying _type parameter

### DIFF
--- a/common/guide.md
+++ b/common/guide.md
@@ -1590,11 +1590,17 @@ If the request was successful, a 202 Accepted response code will be returned wit
 <pre class="highlight"><code>Content-Location: https://sandbox.dpc.cms.gov/api/v1/Jobs/<span style="color: #045E87;">{unique ID of export job}</span></code></pre>
 
 ## Specify which Resources to Download
-The Resources to Export can be specified using the _type Parameter. Multiple Resources are specified in a comma delimited list. The following request will export the Patient and Coverage esources, but NOT the Explanation of Benefit Resource.
+The _type query parameter allows you to specify which FHIR resources you wish to export. If you do not specify a _type parameter in your request, all three resources will be exported. Currently, DPC makes Explanation of Benefit, Patient, and Coverage resources available, which can be specified individually or as a group using a comma delimited list and the syntax `?_type=ExplanationOfBenefit,Patient,Coverage`. 
+
+The following request will export the Patient and Coverage esources, but NOT the Explanation of Benefit Resource.
 
 ### Request:
 <pre class="highlight"><code>GET /api/v1/Group/<span style="color: #045E87;">{attribution group ID}</span>/$export?_type=Patient,Coverage</code></pre>
 
+The following request, by contrast, will export the Explanation of Benefit resource, but NOT the Patient or Coverage resources.
+
+### Request:
+<pre class="highlight"><code>GET /api/v1/Group/<span style="color: #045E87;">{attribution group ID}</span>/$export?_type=ExplanationOfBenefit</code></pre>
 
 ## Requesting filtered data
 


### PR DESCRIPTION


### Fixes [DPC-1373](https://jira.cms.gov/browse/DPC-1373)

Currently, the user guide does not supply parameters or syntax for use of the _type query parameter.

### Proposed Changes

Add language that clearly shows how the _type query parameter can be used to specify one or two resources to export.

### Change Details

Examples using Explanation of Benefit, Patient, and Coverage are provided, with additional explanatory language around the function of _type.

### Security Implications
None; new static site language only

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

_type information in the user guide reflects parameters of Explanation of Benefits, Patient, and Coverage. New language can be used to correctly request parametrized data.

### Feedback Requested

- Does the English syntax make sense? Is it clear?
- Does the sample code make sense? Can you use it to make the request it says you can make?
