### PR TITLE
dpc-1889 Feature: Remove app links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ cssurl: /assets/css/static-main.css
 logourl: /assets/images/top-nav-heart.svg
 sbx_register: "https://sandbox.dpc.cms.gov/users/sign_up"
 sbx_sign_in: "https://sandbox.dpc.cms.gov/users/sign_in"
-pilot_register: "https://airtable.com/shr3m3BL3IWY5hYnm"
+email_register: "mailto:DPCINFO@cms.hhs.gov"
 
 global_nav:
   - title: Home

--- a/_includes/_hero.html
+++ b/_includes/_hero.html
@@ -5,11 +5,8 @@
         Join the Production Pilot Onboarding Queue!
       </div>
       <div class="banner-text__content">
-        For more information, please review the <a href="/faq" id="banner-faq">FAQ</a> about production access.
+        For more information, please review <a href="/pilot" id="banner-pilot">About the Pilot</a> about production access.
       </div>
-    </div>
-    <div class="hero-btn__container">
-      <a href={{ site.pilot_register }} target="_blank" rel=noopener class="sign_up_btn">Apply Now</a>
     </div>
   </div>
 </section>

--- a/common/docsV1.md
+++ b/common/docsV1.md
@@ -7,7 +7,7 @@ id: docsV1
 side_nav_items: guide1_nav
 ---
 
-Welcome to the Data at the Point of Care pilot API program! This documentation covers using the sandbox API with synthetic data. Once you’ve tested your implementation in sandbox, you can sign up for [the queue to be onboarded to the production environment](https://airtable.com/shr3m3BL3IWY5hYnm).
+Welcome to the Data at the Point of Care pilot API program! This documentation covers using the sandbox API with synthetic data. Once you’ve tested your implementation in sandbox, you can [email DPC](mailto:DPCINFO@cms.hhs.gov) to be added to the queue for production access.
 
 # Authorization
 ------------------

--- a/common/faq.html
+++ b/common/faq.html
@@ -111,7 +111,7 @@ button_url: "https://groups.google.com/d/forum/dpc-api"
       </button>
     </h2>
     <div id="c1" class="usa-accordion__content">
-      We're excited to invite you to apply to be a production pilot participant! You can sign up to <a href={{ site.pilot_register }} target="_blank" rel=noopener>join the queue here</a>.
+      We're excited to invite you to apply to be a production pilot participant! You can <a href={{ site.email_register }} target="_blank" rel=noopener>email DPC</a> to be added to the queue for production access.
     </div>
 
     <h2 class="usa-accordion__heading">

--- a/common/pilot.html
+++ b/common/pilot.html
@@ -4,8 +4,8 @@ title: About the Pilot
 banner_title: About the Pilot
 permalink: /pilot
 id: pilot
-button: Apply for Production
-button_url: https://airtable.com/shr3m3BL3IWY5hYnm
+button: Email DPC to Request Production Access
+button_url: mailto:DPCINFO@cms.hhs.gov
 side_nav_items: pilot_nav
 ---
 
@@ -69,7 +69,7 @@ After testing and developing a DPC solution in the sandbox environment:
 
 <h3 id="join-prod-queue">a. Join the Production Pilot Queue</h3>
 
-You will receive a follow-up email from the DPC team when it is your turn to onboard. Depending on the backlog of organizations, this may mean that your organization will sit in the queue for a few weeks before it is your turn to onboard.
+When you're ready to request production access, please <a href={{ site.email_register }} target="_blank" rel=noopener>email</a> the DPC team. You will receive a follow-up email from the DPC team when it is your turn to onboard. Depending on the backlog of organizations, this may mean that your organization will sit in the queue for a few weeks before it is your turn to onboard.
 
 
 <div class="ds-c-alert ds-u-margin-bottom--5 ds-c-alert--warn">


### PR DESCRIPTION
### Fixes [DPC-1889](https://jira.cms.gov/browse/DPC-1889)

We want to replace the airtable form links in the static site, since they could pose a potential security risk, and replace them with email links instead.

### Change Details

- Update banner to point to pilot page instead of faq page.
- Update pilot page airtable links to use email link instead.
- Update docs page airtable link to use email link instead.
- Update faq page airtable link to use email link instead.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

All mentions of the airtable url has been removed and replaced with email links instead.

### Feedback Requested

General feedback as always. I have not found any other mentions of the airtable besides what has been described in the ticket.