### PR TITLE
DPC-2189: Fix Curl Command

### DIFF
--- a/common/docsV1.md
+++ b/common/docsV1.md
@@ -498,7 +498,7 @@ POST /api/v1/Token/auth
 <pre class="highlight"><code>curl -v "https://sandbox.dpc.cms.gov/api/v1/Token/auth" \
      -H 'Content-Type: application/x-www-form-urlencoded' \
      -H 'Accept: application/json' \
-     -X POST
+     -X POST \
      -d "grant_type=client_credentials&scope=system%2F*.*&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=<span style="color: #045E87;">{self-signed JWT}</span>"</code></pre>
 
 #### Response:


### PR DESCRIPTION
### Fixes [DPC-2189](https://jira.cms.gov/browse/DPC-2189)
Fixed the curl command with /ap1/v2/Token/auth by adding a `\` to the end of the line containing Post

### Proposed Changes
- Fix the syntax of the curl command by adding a backslash

### Change Details
- Line 501 added a `\` at the end of the line

### Security Implications
- Syntax change to the existing content and does not expose any new security vulnerabilities

### Acceptance Validation
- Passes the build and test with no issues

### Feedback Requested
- Ability to build without any errors

(getting the DPC static site repo setup along with going through the process of making a change then deploying)
