### PR TITLE
Update page permalinks

### DIFF
--- a/common/data.md
+++ b/common/data.md
@@ -2,7 +2,7 @@
 layout: page-sidenav
 title: DPC Data
 banner_title: Understanding DPC Data
-permalink: /data
+permalink: /data.html
 id: data
 button: Data Dictionary
 coming_soon: true

--- a/common/docsV1.md
+++ b/common/docsV1.md
@@ -2,7 +2,7 @@
 layout: page-sidenav
 title: DPC Documentation
 banner_title: Documentation
-permalink: /docsV1
+permalink: /docsV1.html
 id: docsV1
 side_nav_items: guide1_nav
 ---

--- a/common/docsV2.md
+++ b/common/docsV2.md
@@ -2,7 +2,7 @@
 layout: page-sidenav
 title: DPC Documentation
 banner_title: Documentation
-permalink: /docsV2
+permalink: /docsV2.html
 id: docsV2
 button: Sign Up for Sandbox
 button_url: https://sandbox.dpc.cms.gov/users/sign_in

--- a/common/faq.html
+++ b/common/faq.html
@@ -3,7 +3,7 @@ layout: page-info
 title: Frequently asked questions
 banner_title: Frequently asked questions
 description: Frequently asked questions about the Data at the Point of Care pilot
-permalink: /faq
+permalink: /faq.html
 id: faq
 button: DPC Google Group
 button_url: "https://groups.google.com/d/forum/dpc-api"

--- a/common/pilot.html
+++ b/common/pilot.html
@@ -2,7 +2,7 @@
 layout: page-sidenav
 title: About the Pilot
 banner_title: About the Pilot
-permalink: /pilot
+permalink: /pilot.html
 id: pilot
 button: Email DPC to Request Production Access
 button_url: mailto:DPCINFO@cms.hhs.gov

--- a/common/tos.md
+++ b/common/tos.md
@@ -1,7 +1,7 @@
 ---
 layout: page-tos
 title: Terms of service
-permalink: /terms-of-service
+permalink: /terms-of-service.html
 id: tos
 ---
 *Last updated: 8/19/21*

--- a/common/update-page.md
+++ b/common/update-page.md
@@ -2,7 +2,7 @@
 layout: page-info
 title: Updates
 banner_title: Updates
-permalink: /updates
+permalink: /updates.html
 id: updates
 button: DPC Google Group
 button_url: "https://groups.google.com/d/forum/dpc-api"


### PR DESCRIPTION
### Fixes [DPC-2999](https://jira.cms.gov/browse/DPC-2999)

Static site pages with permalinks that have no file extension do not get picked up in AWS 

### Proposed Changes

* Update page permalinks to include .html - Since the built files have the .html extension when we push them to S3, the links must have the extension as well
* Should not affect the SS in Akamai

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

### Acceptance Validation

<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
