### PR TITLE
DPC-3595: Fix broken links flagged by htmlchecker

### DIFF
--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -40,7 +40,7 @@
           <li><a target="_blank" rel=noopener href="https://www.foia.gov/">Freedom of Information Act</a></li>
           <li><a target="_blank" rel=noopener href="https://oig.hhs.gov/">Inspector General</a></li>
           <li><a target="_blank" rel=noopener href="https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/NoFearAct.html">No Fear Act</a></li>
-          <li><a target="_blank" rel=noopener href="https://www.medicare.gov/about-us/plain-writing/plain-writing.html">Plain Writing</a></li>
+          <li><a target="_blank" rel=noopener href="https://www.medicare.gov/about-us/plain-writing">Plain Writing</a></li>
           <li><a target="_blank" rel=noopener href="https://www.usa.gov/">USA.gov</a></li>
           <li><a target="_blank" rel=noopener href="https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/Privacy-Policy">CMS Privacy Policy</a></li>
           <li><a target="_blank" rel=noopener href="https://www.cms.gov/vulnerability-disclosure-policy">CMS/HHS Vulnerability Disclosure Policy</a></li>

--- a/common/pilot.html
+++ b/common/pilot.html
@@ -37,7 +37,7 @@ side_nav_items: pilot_nav
 Reference the following guides to get started:
 <ol>
   <li>
-    <a href="https://dpc.cms.gov/docsV1" target="_blank" rel=noopener>DPC Documentation</a>
+    <a href="https://dpc.cms.gov/docsV1.html" target="_blank" rel=noopener>DPC Documentation</a>
   </li>
   <li>
     <a href="https://www.hl7.org/fhir/" target="_blank" rel=noopener>HL7 FHIR Standards</a>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3595

## 🛠 Changes

- Fix broken links on the pilot page and footer

## ℹ️ Context for reviewers

There are two broken links that have been on the website. I used htmlchecker to discover these:

```
$ bundle add htmlchecker
$ docker-compose -f docker-compose.yml build static_site 
$ docker-compose -f docker-compose.yml run --rm static_site
$ bundle exec htmlproofer --assume_extension '.html' --checks 'Links' ./_site
```

It outputs a bunch of info, but the main interests for broken links are issues related to `status code 404`.

## ✅ Acceptance Validation

Checked the two new links manually.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.
