### PR TITLE
DPC-3649 replace ndjson.org with github/ndjson-spec

### DIFF
--- a/common/data.md
+++ b/common/data.md
@@ -45,6 +45,6 @@ In order to aid in users' understanding of DPC file data and structure, we provi
 2. [Bulk FHIR specification](http://build.fhir.org/ig/HL7/VhDir/bulk-data.html)
 3. [Beneficiary FHIR Data Server (BFD)/ Blue Button API](https://bluebutton.cms.gov/developers/)
 4. [Beneficiary FHIR Data Server (BFD)/ Blue Button Implementation Guide](https://bluebutton.cms.gov/assets/ig/index.html)
-5. [Intro to JSON Format](https://www.json.org/json-en.html) and [NDJSON.org](http://ndjson.org/)
+5. [Intro to JSON Format](https://www.json.org/json-en.html) and [NDJSON](https://github.com/ndjson/ndjson-spec)
 6. [JSON format viewer/validator (raw text/JSON format converter)](https://jsonlint.com/)
 7. [Intro to valid FHIR formats](http://hl7.org/fhir/STU3/validation.html)

--- a/common/docsV1.md
+++ b/common/docsV1.md
@@ -1776,12 +1776,12 @@ Claims data can be found at the URLs within the output field.
 
 The output includes file integrity information in an extension array. It contains https://dpc.cms.gov/checksum (a checksum in the format algorithm:checksum) and https://dpc.cms.gov/file_length (the file length in bytes).
 
-The number 42 in the example data file URLs is the same job ID from the Content-Location header URL when you initiate an export job. If some of the data cannot be exported due to errors, details of the errors can be found at the URLs in the error field. The errors are provided in <a href="http://ndjson.org/" target="_blank" and rel=noopener>NDJSON</a> files as FHIR <a href="http://hl7.org/fhir/STU3/operationoutcome.html" target="_blank" and rel=noopener>OperationOutcome</a> resources.
+The number 42 in the example data file URLs is the same job ID from the Content-Location header URL when you initiate an export job. If some of the data cannot be exported due to errors, details of the errors can be found at the URLs in the error field. The errors are provided in <a href="https://github.com/ndjson/ndjson-spec" target="_blank" and rel=noopener>NDJSON</a> files as FHIR <a href="http://hl7.org/fhir/STU3/operationoutcome.html" target="_blank" and rel=noopener>OperationOutcome</a> resources.
 
 
 
 ## Retrieve the NDJSON output file(s)
-To obtain the exported explanation of benefit data, a GET request is made to the output URLs in the job status response when the job reaches the Completed state. The data will be presented as an <a href="http://ndjson.org/" target="_blank" and rel=noopener>NDJSON</a> file of ExplanationOfBenefit Resources.
+To obtain the exported explanation of benefit data, a GET request is made to the output URLs in the job status response when the job reaches the Completed state. The data will be presented as an <a href="https://github.com/ndjson/ndjson-spec" target="_blank" and rel=noopener>NDJSON</a> file of ExplanationOfBenefit Resources.
 
 <div class="ds-c-alert ds-c-alert--warn">
   <div class="ds-c-alert__body">


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3649

## 🛠 Changes

References to http://ndjson.org replaced with https://github.com/ndjson/ndjson-spec

## ℹ️ Context for reviewers

(Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.)

## ✅ Acceptance Validation

Grepped the directory before and after. Before (that is, on master) I found four instances across two files. After changes, I found no references to ndjson.org.
`grep -ri --exclude-dir ".git" "ndjson.org" .`

Also verified links locally at http://localhost:4001/data.html and http://localhost:4001/docsv1.html

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
