### PR TITLE
DPC-3779: Set JEKYLL_ENV when building docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/Dockerfile.static_site
+    environment:
+      JEKYLL_ENV: ${JEKYLL_ENV:-dev}
     volumes:
       - ./_site:/dpc-site-static/_site
       - ./.jekyll-cache:/dpc-site-static/.jekyll-cache


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3779

## 🛠 Changes

- Set JEKYLL_ENV so it's used when building the docker image

## ℹ️ Context for reviewers

The JEKYLL_ENV isn't read by docker (even it's set in the local environment), so `jekyll.environment` always evaluates to `development`.

## ✅ Acceptance Validation

Build image:
```
export JEKYLL_ENV=prod
docker-compose -f docker-compose.yml build static_site
```

Then started a container and checked the _site/index.html to verify that it's using the prod tag for Adobe Analytics.

Also deployed to stage and confirmed it's using the `qa` URL.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
