### PR TITLE
[DPC-3050] Remove MyMedicare from footer

### DIFF
--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -25,7 +25,6 @@
         <ul class="ds-c-list ds-c-list--bare ds-u-font-size--small">
           <li><a target="_blank" rel=noopener href="https://www.cms.gov/">CMS.gov</a></li>
           <li><a target="_blank" rel=noopener href="https://www.medicare.gov/">Medicare.gov</a></li>
-          <li><a target="_blank" rel=noopener href="https://www.mymedicare.gov/">MyMedicare.gov</a></li>
           <li><a target="_blank" rel=noopener href="https://www.medicaid.gov/">Medicaid.gov</a></li>
           <li><a target="_blank" rel=noopener href="https://www.healthcare.gov/">Healthcare.gov</a></li>
           <li><a target="_blank" rel=noopener href="https://www.hhs.gov/">HHS.gov</a></li>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/3050

## 🛠 Changes

Removes MyMedicare.gov from page footer.

## ℹ️ Context

The footer previously linked to both Medicare.gov and MyMedicare.gov, the latter of which is deprecated and resolves to the login page for Medicare.gov.

## 🧪 Validation

Previous footer:
![image](https://github.com/CMSgov/dpc-static-site/assets/134093673/35b4bcdd-bda4-4b2f-b6e8-547fbfa5f477)

Updated footer:
![image](https://github.com/CMSgov/dpc-static-site/assets/134093673/a8e28309-e995-4487-8fae-f24fc2619008)
