### PR TITLE
Me/dpc 4183 update bulk fhir link

### DIFF
--- a/common/data.md
+++ b/common/data.md
@@ -42,7 +42,7 @@ In order to aid in users' understanding of DPC file data and structure, we provi
 ## Additional Resources
 
 1. [FHIR/HL7](https://www.hl7.org/fhir/)
-2. [Bulk FHIR specification](https://hl7.org/fhir/uv/bulkdata/ )
+2. [Bulk FHIR specification](https://hl7.org/fhir/uv/bulkdata/)
 3. [Beneficiary FHIR Data Server (BFD)/ Blue Button API](https://bluebutton.cms.gov/developers/)
 4. [Beneficiary FHIR Data Server (BFD)/ Blue Button Implementation Guide](https://bluebutton.cms.gov/assets/ig/index.html)
 5. [Intro to JSON Format](https://www.json.org/json-en.html) and [NDJSON](https://github.com/ndjson/ndjson-spec)

--- a/common/data.md
+++ b/common/data.md
@@ -42,7 +42,7 @@ In order to aid in users' understanding of DPC file data and structure, we provi
 ## Additional Resources
 
 1. [FHIR/HL7](https://www.hl7.org/fhir/)
-2. [Bulk FHIR specification](http://build.fhir.org/ig/HL7/VhDir/bulk-data.html)
+2. [Bulk FHIR specification](https://hl7.org/fhir/uv/bulkdata/ )
 3. [Beneficiary FHIR Data Server (BFD)/ Blue Button API](https://bluebutton.cms.gov/developers/)
 4. [Beneficiary FHIR Data Server (BFD)/ Blue Button Implementation Guide](https://bluebutton.cms.gov/assets/ig/index.html)
 5. [Intro to JSON Format](https://www.json.org/json-en.html) and [NDJSON](https://github.com/ndjson/ndjson-spec)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4183

## 🛠 Changes

Update the bulk fhir link on the dpc data page.

## ℹ️ Context

The old link pointed to an outdated version of the bulk fhir page and needed to be updated.

## 🧪 Validation

Ran locally.
