### PR TITLE
DPC-4438 Check static site for 508 compliance via github actions

### DIFF
--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -3,12 +3,12 @@ name: Check 508 Compliance
 on:
   push:
     paths:
-      - .github/worflows/check_508_compliance.yml
+      - .github/workflows/check_508_compliance.yml
 
 jobs:
   compliance_check:
     steps:
-      - name: Run Axe
+      - name: Run Axe Check
         env:
           TARGET_BASE_URL: 'https://stage.dpc.cms.gov'
         run: |

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -21,6 +21,6 @@ jobs:
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV1.html"
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV2.html" 
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/updates.html"
-          RESULTS=`docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}`
-          echo $RESULTS
+          echo $TARGETS_TO_SCAN
+          docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 $TARGETS_TO_SCAN
           

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -10,7 +10,11 @@ jobs:
     name: Compliance Check
     runs-on: ubuntu-latest
     steps:
+      - name: Sanity check
+        run: |
+          curl -v https://stage.dpc.cms.gov
       - name: Run Axe Check
+        if: ${{ 'foo' == 'bar' }}
         env:
           TARGET_BASE_URL: 'https://stage.dpc.cms.gov'
         run: |

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -10,13 +10,9 @@ jobs:
     name: Compliance Check
     runs-on: ubuntu-latest
     steps:
-      - name: Sanity check
-        run: |
-          curl -v https://stage.dpc.cms.gov
       - name: Run Axe Check
-        if: ${{ 'foo' == 'bar' }}
         env:
-          TARGET_BASE_URL: 'https://stage.dpc.cms.gov'
+          TARGET_BASE_URL: 'https://dpc.cms.gov'
         run: |
           TARGETS_TO_SCAN="${TARGET_BASE_URL}"
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/faq.html"

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   compliance_check:
+    name: Compliance Check
+    runs-on: ubuntu-latest
     steps:
       - name: Run Axe Check
         env:

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -14,13 +14,13 @@ jobs:
         env:
           TARGET_BASE_URL: 'https://stage.dpc.cms.gov'
         run: |
-          TARGETS_TO_SCAN="${TARGET_TEST_ENV}"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/faq.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/data.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/pilot.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2.html" 
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates.html"
+          TARGETS_TO_SCAN="${TARGET_BASE_URL}"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/faq.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/data.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/pilot.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV1.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV2.html" 
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/updates.html"
           RESULTS=`docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}`
           echo $RESULTS
           

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -1,0 +1,24 @@
+name: Check 508 Compliance
+
+on:
+  push:
+    paths:
+      - .github/worflows/check_508_compliance.yml
+
+jobs:
+  compliance_check:
+    steps:
+      - name: Run Axe
+        env:
+          TARGET_BASE_URL: 'https://stage.dpc.cms.gov'
+        run: |
+          TARGETS_TO_SCAN="${TARGET_TEST_ENV}"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/faq.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/data.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/pilot.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2.html" 
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates.html"
+          RESULTS=`docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}`
+          echo $RESULTS
+          

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -1,18 +1,27 @@
 name: Check 508 Compliance
 
 on:
-  push:
-    paths:
-      - .github/workflows/check_508_compliance.yml
+  schedule:
+    - cron: 17 8 * * 1
+  workflow_dispatch:
+    inputs:
+      target_host:
+        description: Check where?
+        required: true
+        default: 'https://stage.dpc.cms.gov'
+        type: choice
+        options:
+          - 'https://stage.dpc.cms.gov'
+          - 'https://dpc.cms.gov'
 
 jobs:
   compliance_check:
     name: Compliance Check
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Run Axe Check
         env:
-          TARGET_BASE_URL: 'https://dpc.cms.gov'
+          TARGET_BASE_URL: ${{ inputs.target_host || 'https://stage.dpc.cms.gov' }}
         run: |
           TARGETS_TO_SCAN="${TARGET_BASE_URL}"
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/faq.html"
@@ -21,6 +30,5 @@ jobs:
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV1.html"
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV2.html" 
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/updates.html"
-          echo $TARGETS_TO_SCAN
           docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 $TARGETS_TO_SCAN
           

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,7 +1,7 @@
 name: "DPC Static Site CI Workflow"
 
-on:
-  workflow_call:
+on: [push]
+
 jobs:
   build:
     name: "Build and Test"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,7 +1,7 @@
 name: "DPC Static Site CI Workflow"
 
-on: [push]
-
+on:
+  workflow_call:
 jobs:
   build:
     name: "Build and Test"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4438

## 🛠 Changes

Added check_508_compliance workflow.

## ℹ️ Context

We are moving our jobs from Jenkins to github actions. This is a clone of [Jenkinsfile.static_site_508_compliance](https://github.com/CMSgov/dpc-ops/blob/main/jenkins_files/Jenkinsfile.static_site_508_compliance)

## 🧪 Validation
Forced run worked: https://github.com/CMSgov/dpc-static-site/actions/runs/12380895523
Forced run with failure (running on ubuntu-latest meant it was blocked, so it tested the Cloudfront 403 response): https://github.com/CMSgov/dpc-static-site/actions/runs/12379865142/job/34554969116
