### PR TITLE
Send Slack messages from Github Actions

### DIFF
--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -46,7 +46,7 @@ jobs:
                   - text
       - uses: slackapi/slack-github-action@v2.0.0
         name: Slack failure
-        if: ${{ falure() }}
+        if: ${{ failure() }}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -31,4 +31,30 @@ jobs:
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV2.html" 
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/updates.html"
           docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 $TARGETS_TO_SCAN
-          
+      - uses: slackapi/slack-github-action@v2.0.0
+        name: Slack Success
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to dpc-deploys
+          payload: |
+            channel: "CMC1E4AEQ"
+            attachments:
+              - color: good
+                text: SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ inputs.target_host }}`"
+                mrkdown_in:
+                  - text
+      - uses: slackapi/slack-github-action@v2.0.0
+        name: Slack failure
+        if: ${{ falure() }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to dpc-deploys
+          payload: |
+            channel: "CMC1E4AEQ"
+            attachments:
+              - color: danger
+                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ inputs.target_host }}`"
+                mrkdown_in:
+                  - text

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -41,7 +41,7 @@ jobs:
             channel: "CMC1E4AEQ"
             attachments:
               - color: good
-                text: SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ inputs.target_host }}`"
+                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ inputs.target_host }}`"
                 mrkdown_in:
                   - text
       - uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,7 +96,7 @@ jobs:
             channel: "CMC1E4AEQ"
             attachments:
               - color: good
-                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }} deployed to ${{ inputs.target_environment }} environment."
+                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }}` deployed to ${{ inputs.target_environment }} environment."
                 mrkdown_in:
                   - text
       - uses: slackapi/slack-github-action@v2.0.0
@@ -110,6 +110,6 @@ jobs:
             channel: "CMC1E4AEQ"
             attachments:
               - color: danger
-                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }} deployed to ${{ inputs.target_environment }} environment."
+                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }}` deployed to ${{ inputs.target_environment }} environment."
                 mrkdown_in:
                   - text

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,7 +96,7 @@ jobs:
             channel: "CMC1E4AEQ"
             attachments:
               - color: good
-                text: SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }} deployed to ${{ inputs.target_environment }} environment."
+                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }} deployed to ${{ inputs.target_environment }} environment."
                 mrkdown_in:
                   - text
       - uses: slackapi/slack-github-action@v2.0.0
@@ -110,6 +110,6 @@ jobs:
             channel: "CMC1E4AEQ"
             attachments:
               - color: danger
-                text: FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }} deployed to ${{ inputs.target_environment }} environment."
+                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }} deployed to ${{ inputs.target_environment }} environment."
                 mrkdown_in:
                   - text

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,7 +101,7 @@ jobs:
                   - text
       - uses: slackapi/slack-github-action@v2.0.0
         name: Slack failure
-        if: ${{ falure() }}
+        if: ${{ failure() }}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,3 +86,30 @@ jobs:
         run: |
           DISTRIBUTION_ID=`aws cloudfront list-distributions --query "DistributionList.Items[].{Id:Id, OriginDomainName: Origins.Items[0].DomainName}[?starts_with(OriginDomainName, '$TARGET_BUCKET')].Id" --output text`
           aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'
+      - uses: slackapi/slack-github-action@v2.0.0
+        name: Slack Success
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to dpc-deploys
+          payload: |
+            channel: "CMC1E4AEQ"
+            attachments:
+              - color: good
+                text: SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }} deployed to ${{ inputs.target_environment }} environment."
+                mrkdown_in:
+                  - text
+      - uses: slackapi/slack-github-action@v2.0.0
+        name: Slack failure
+        if: ${{ falure() }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to dpc-deploys
+          payload: |
+            channel: "CMC1E4AEQ"
+            attachments:
+              - color: danger
+                text: FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }} deployed to ${{ inputs.target_environment }} environment."
+                mrkdown_in:
+                  - text


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

Slack stanzas added to deploy and 508 compliance check

## ℹ️ Context

Jenkins jobs sent messages to slack after deploys and 508 checks.
Tagging will send message from deploy workflow.

## 🧪 Validation

Ran 508 check and deploy and success messages went to slack:
508: [run](https://github.com/CMSgov/dpc-static-site/actions/runs/12657523586) [slack](https://cmsgov.slack.com/archives/CMC1E4AEQ/p1736276157869379)
deploy: [run](https://github.com/CMSgov/dpc-static-site/actions/runs/12657691685) [slack](https://cmsgov.slack.com/archives/CMC1E4AEQ/p1736276913373869)
