### PR TITLE
Fix 508 Static Site compliance check success message when run from cron

### DIFF
--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Set Target Base
-        -id: target-base
+        id: target-base
         run: |
           echo "${{ inputs.target_host || 'https://stage.dpc.cms.gov' }}=TARGET_BASE_URL" >> "$GITHUB_OUTPUT"
       - name: Run Axe Check

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -27,38 +27,4 @@ jobs:
         env:
           TARGET_BASE_URL: ${{ steps.target-base.outputs.TARGET_BASE_URL }}
         run: |
-          TARGETS_TO_SCAN="${TARGET_BASE_URL}"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/faq.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/data.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/pilot.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV1.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV2.html" 
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/updates.html"
-          docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 $TARGETS_TO_SCAN
-      - uses: slackapi/slack-github-action@v2.0.0
-        name: Slack Success
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          # Sends to dpc-deploys
-          payload: |
-            channel: "CMC1E4AEQ"
-            attachments:
-              - color: good
-                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.TARGET_BASE_URL }}`"
-                mrkdown_in:
-                  - text
-      - uses: slackapi/slack-github-action@v2.0.0
-        name: Slack failure
-        if: ${{ failure() }}
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          # Sends to dpc-deploys
-          payload: |
-            channel: "CMC1E4AEQ"
-            attachments:
-              - color: danger
-                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.TARGET_BASE_URL }}`"
-                mrkdown_in:
-                  - text
+          echo $TARGET_BASE_URL

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -19,9 +19,13 @@ jobs:
     name: Compliance Check
     runs-on: self-hosted
     steps:
+      - name: Set Target Base
+        -id: target-base
+        run: |
+          echo "${{ inputs.target_host || 'https://stage.dpc.cms.gov' }}=TARGET_BASE_URL" >> "$GITHUB_OUTPUT"
       - name: Run Axe Check
         env:
-          TARGET_BASE_URL: ${{ inputs.target_host || 'https://stage.dpc.cms.gov' }}
+          TARGET_BASE_URL: ${{ steps.target-base.outputs.target-base }}
         run: |
           TARGETS_TO_SCAN="${TARGET_BASE_URL}"
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/faq.html"
@@ -41,7 +45,7 @@ jobs:
             channel: "CMC1E4AEQ"
             attachments:
               - color: good
-                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ inputs.target_host }}`"
+                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.target-base }}`"
                 mrkdown_in:
                   - text
       - uses: slackapi/slack-github-action@v2.0.0
@@ -55,6 +59,6 @@ jobs:
             channel: "CMC1E4AEQ"
             attachments:
               - color: danger
-                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ inputs.target_host }}`"
+                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.target-base }}`"
                 mrkdown_in:
                   - text

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -25,7 +25,7 @@ jobs:
           echo "${{ inputs.target_host || 'https://stage.dpc.cms.gov' }}=TARGET_BASE_URL" >> "$GITHUB_OUTPUT"
       - name: Run Axe Check
         env:
-          TARGET_BASE_URL: ${{ steps.target-base.outputs.target-base }}
+          TARGET_BASE_URL: ${{ steps.target-base.outputs.TARGET_BASE_URL }}
         run: |
           TARGETS_TO_SCAN="${TARGET_BASE_URL}"
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/faq.html"
@@ -45,7 +45,7 @@ jobs:
             channel: "CMC1E4AEQ"
             attachments:
               - color: good
-                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.target-base }}`"
+                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.TARGET_BASE_URL }}`"
                 mrkdown_in:
                   - text
       - uses: slackapi/slack-github-action@v2.0.0
@@ -59,6 +59,6 @@ jobs:
             channel: "CMC1E4AEQ"
             attachments:
               - color: danger
-                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.target-base }}`"
+                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.TARGET_BASE_URL }}`"
                 mrkdown_in:
                   - text

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -22,9 +22,43 @@ jobs:
       - name: Set Target Base
         id: target-base
         run: |
-          echo "${{ inputs.target_host || 'https://stage.dpc.cms.gov' }}=TARGET_BASE_URL" >> "$GITHUB_OUTPUT"
+          echo "TARGET_BASE_URL=${{ inputs.target_host || 'https://stage.dpc.cms.gov' }}" >> "$GITHUB_OUTPUT"
       - name: Run Axe Check
         env:
           TARGET_BASE_URL: ${{ steps.target-base.outputs.TARGET_BASE_URL }}
         run: |
-          echo $TARGET_BASE_URL
+          TARGETS_TO_SCAN="${TARGET_BASE_URL}"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/faq.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/data.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/pilot.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV1.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV2.html" 
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/updates.html"
+          docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 $TARGETS_TO_SCAN
+      - uses: slackapi/slack-github-action@v2.0.0
+        name: Slack Success
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to dpc-deploys
+          payload: |
+            channel: "CMC1E4AEQ"
+            attachments:
+              - color: good
+                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.TARGET_BASE_URL }}`"
+                mrkdown_in:
+                  - text
+      - uses: slackapi/slack-github-action@v2.0.0
+        name: Slack failure
+        if: ${{ failure() }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to dpc-deploys
+          payload: |
+            channel: "CMC1E4AEQ"
+            attachments:
+              - color: danger
+                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.TARGET_BASE_URL }}`"
+                mrkdown_in:
+                  - text


### PR DESCRIPTION
## 🎫 Ticket

No Ticket

## 🛠 Changes

Target base url set in one step for use in later steps

## ℹ️ Context

The slack message for success/failure of the 508 compliance check was using the url from the input, but cron does not set inputs. Instead, I am setting the 

## 🧪 Validation

Checks ran with appropriate messages
