### PR TITLE
DPC:4561 Updated Readme.md and qa.html to point to correct wiki location confluence.hl7.org

### DIFF
--- a/ig/qa.html
+++ b/ig/qa.html
@@ -93,7 +93,7 @@
 <h2><a href="">n/a</a></h2>
  <table class="grid">
    <tr style="background-color: #ffffe6">
-     <td><b>CapabilityStatement-dpc-capabilities.html</b></td><td><b>information</b></td><td><b>The html source does not contain the publish box; this is recommended for publishing support  (see note at http://confluence.hl7.org/index.php?title=FHIR_Implementation_Guide_Publishing_Requirements#HL7_HTML_Standards_considerations). Note that this is mandatory for HL7 specifications, and on the ci-build, but in other cases it's still recommended (this is only reported once, but applies for all pages)</b></td>
+     <td><b>CapabilityStatement-dpc-capabilities.html</b></td><td><b>information</b></td><td><b>The html source does not contain the publish box; this is recommended for publishing support  (see note at https://confluence.hl7.org/spaces/FHIR/pages/66930646/FHIR+Implementation+Guide+Publishing+Requirements). Note that this is mandatory for HL7 specifications, and on the ci-build, but in other cases it's still recommended (this is only reported once, but applies for all pages)</b></td>
    </tr>
    <tr style="background-color: #ffcccc">
      <td><b><a href="CapabilityStatement-dpc-capabilities.html#bf3a6b61-7d23-424e-a930-93972628ee27">CapabilityStatement-dpc-capabilities.html#/html/head/link/body/div/div/a at Line 43, column 7</a></b></td><td><b>error</b></td><td><b>The link '/ig/index.html' for &quot;null&quot; cannot be resolved</b></td>

--- a/ig/qa.html
+++ b/ig/qa.html
@@ -93,7 +93,7 @@
 <h2><a href="">n/a</a></h2>
  <table class="grid">
    <tr style="background-color: #ffffe6">
-     <td><b>CapabilityStatement-dpc-capabilities.html</b></td><td><b>information</b></td><td><b>The html source does not contain the publish box; this is recommended for publishing support  (see note at http://wiki.hl7.org/index.php?title=FHIR_Implementation_Guide_Publishing_Requirements#HL7_HTML_Standards_considerations). Note that this is mandatory for HL7 specifications, and on the ci-build, but in other cases it's still recommended (this is only reported once, but applies for all pages)</b></td>
+     <td><b>CapabilityStatement-dpc-capabilities.html</b></td><td><b>information</b></td><td><b>The html source does not contain the publish box; this is recommended for publishing support  (see note at http://confluence.hl7.org/index.php?title=FHIR_Implementation_Guide_Publishing_Requirements#HL7_HTML_Standards_considerations). Note that this is mandatory for HL7 specifications, and on the ci-build, but in other cases it's still recommended (this is only reported once, but applies for all pages)</b></td>
    </tr>
    <tr style="background-color: #ffcccc">
      <td><b><a href="CapabilityStatement-dpc-capabilities.html#bf3a6b61-7d23-424e-a930-93972628ee27">CapabilityStatement-dpc-capabilities.html#/html/head/link/body/div/div/a at Line 43, column 7</a></b></td><td><b>error</b></td><td><b>The link '/ig/index.html' for &quot;null&quot; cannot be resolved</b></td>

--- a/implementation_guide/README.md
+++ b/implementation_guide/README.md
@@ -62,7 +62,7 @@ This is the auto-generated file specified in the `base` field of the `ig.json` f
 
 ## Build the IG
 
-The FHIR group has created an [IG Publisher](http://confluence.hl7.org/index.php?title=IG_Publisher_Documentation) which automates the process of generating the HTML files and documents in the layout expected by FHIR developers.
+The FHIR group has created an [IG Publisher](https://confluence.hl7.org/display/FHIR/IG+Publisher+Documentation) which automates the process of generating the HTML files and documents in the layout expected by FHIR developers.
 
 The IG publisher is a Java application that can be downloaded from the HL7 (link above), or automatically when running the `make ig/publish` command.
 

--- a/implementation_guide/README.md
+++ b/implementation_guide/README.md
@@ -62,7 +62,7 @@ This is the auto-generated file specified in the `base` field of the `ig.json` f
 
 ## Build the IG
 
-The FHIR group has created an [IG Publisher](http://wiki.hl7.org/index.php?title=IG_Publisher_Documentation) which automates the process of generating the HTML files and documents in the layout expected by FHIR developers.
+The FHIR group has created an [IG Publisher](http://confluence.hl7.org/index.php?title=IG_Publisher_Documentation) which automates the process of generating the HTML files and documents in the layout expected by FHIR developers.
 
 The IG publisher is a Java application that can be downloaded from the HL7 (link above), or automatically when running the `make ig/publish` command.
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/...

## 🛠 Changes

Updated Readme.md and qa.html to point to correct wiki location confluence.hl7.org

## ℹ️ Context

The implementation guide includes links to wiki.hl7.org, which has been migrated to confluence.hl7.org. The wiki no longer has a valid certificate, which is causing issues with the link checker. The page on the wiki has a link to the relevant confluence page.


## 🧪 Validation

No references to older link in teh static site project 
