### PR TITLE
[dpc-4692] Add release-gf workflow

### DIFF
--- a/.github/workflows/deploy-gf.yml
+++ b/.github/workflows/deploy-gf.yml
@@ -9,7 +9,7 @@ on:
         default: 'dev'
         type: choice
         options:
-          - dev
+          - dev # TODO: Remove when the upper env's are built and we stop using dev
           - staging
           - prod
       static_repo_ref:
@@ -62,11 +62,7 @@ jobs:
       - name: 'Build Site'
         run: docker run -v ./_site:/dpc-site-static/_site -v ./.jekyll-cache:/dpc-site-static/.jekyll-cache --rm static_site
 
-      - name: Debug output
-        run: |
-          echo "env = ${{ inputs.env }}"
-          echo "region = ${{ vars.AWS_REGION }}"
-
+      # TODO: Remove when the upper env's are built and we stop using dev
       - name: AWS Credentials (non-prod)
         if: ${{ inputs.env == 'dev' || inputs.env == 'test' }}
         uses: aws-actions/configure-aws-credentials@v4
@@ -75,11 +71,11 @@ jobs:
          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
 
       - name: AWS Credentials (prod)
-        if: ${{ inputs.env == 'prod-sbx' || inputs.env == 'prod' }}
+        if: ${{ inputs.env == 'staging' || inputs.env == 'prod' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
          aws-region: ${{ vars.AWS_REGION }}
-         role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
+         role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/dpc-${{ inputs.env == 'staging' && 'prod-sbx' || inputs.env }}-github-actions
 
       - name: Set env vars from AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main

--- a/.github/workflows/deploy-gf.yml
+++ b/.github/workflows/deploy-gf.yml
@@ -1,0 +1,146 @@
+name: 'Deploy Static Site (Greenfield)'
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: Deploy where?
+        required: false
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
+      static_repo_ref:
+        description: Which branch or tag?
+        required: true
+        default: 'main'
+        type: 'string'
+  workflow_call:
+    inputs:
+      env:
+        description: Deploy where?
+        required: false
+        default: 'staging'
+        type: 'string'
+      static_repo_ref:
+        description: Which branch or tag?
+        required: true
+        default: 'main'
+        type: 'string'
+
+jobs:
+  deploy_static_site:
+    name: Deploy Static Site
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+        with:
+          repository: 'CMSgov/dpc-static-site'
+          ref: ${{ inputs.static_repo_ref }}
+
+      - name: "Set Version"
+        env:
+          STATIC_REPO_REF: ${{ inputs.static_repo_ref }}
+        run: |
+          echo "version: $STATIC_REPO_REF" >> _version_config.yml
+
+      - name: "Add dirs"
+        run: mkdir -p _site && mkdir -p .jekyll-cache
+
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+
+      - name: 'Build Image'
+        run: docker build . -f Dockerfiles/Dockerfile.static_site -t static_site
+
+      - name: 'Build Site'
+        run: docker run -v ./_site:/dpc-site-static/_site -v ./.jekyll-cache:/dpc-site-static/.jekyll-cache --rm static_site
+
+      - name: Debug output
+        run: |
+          echo "env = ${{ inputs.env }}"
+          echo "region = ${{ vars.AWS_REGION }}"
+
+      - name: AWS Credentials (non-prod)
+        if: ${{ inputs.env == 'dev' || inputs.env == 'test' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+         aws-region: ${{ vars.AWS_REGION }}
+         role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
+
+      - name: AWS Credentials (prod)
+        if: ${{ inputs.env == 'prod-sbx' || inputs.env == 'prod' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+         aws-region: ${{ vars.AWS_REGION }}
+         role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
+
+      - name: Set env vars from AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            TARGET_BUCKET=/dpc/${{ inputs.env == 'staging' && 'prod-sbx' || inputs.env }}/static_site
+
+      - name: Run quality gate scan
+        if: ${{ inputs.env == 'staging' }}
+        uses: sonarsource/sonarqube-scan-action@master
+        with:
+          args:
+            -Dsonar.projectKey=bcda-dpc-static-site
+            -Dsonar.sources=.
+            -Dsonar.working.directory=./sonar_workspace
+            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
+            -Dsonar.qualitygate.wait=true
+
+      - name: "Sync _site"
+        run: aws s3 sync _site/ s3://"$TARGET_BUCKET"/ --delete
+      - name: Upload html files without suffix with content-language set
+        run: |
+          for file in _site/*.html; do
+            suffixless=`basename ${file/.html}`
+            aws s3 cp $file s3://"$TARGET_BUCKET"/$suffixless --content-language text/html
+          done
+
+      # TODO: Re-enable this when Cloudfront is configured in GF
+      #- name: Invalidate Cloudfront cache
+      #  run: |
+      #    DISTRIBUTION_ID=`aws cloudfront list-distributions --query "DistributionList.Items[].{Id:Id, OriginDomainName: Origins.Items[0].DomainName}[?starts_with(OriginDomainName, '$TARGET_BUCKET')].Id" --output text`
+      #    aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'
+
+      - uses: slackapi/slack-github-action@v2.0.0
+        name: Slack Success
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to dpc-deploys
+          payload: |
+            channel: "CMC1E4AEQ"
+            attachments:
+              - color: good
+                text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }}` deployed to ${{ inputs.env }} environment."
+                mrkdown_in:
+                  - text
+
+      - uses: slackapi/slack-github-action@v2.0.0
+        name: Slack failure
+        if: ${{ failure() }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to dpc-deploys
+          payload: |
+            channel: "CMC1E4AEQ"
+            attachments:
+              - color: danger
+                text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }}` deployed to ${{ inputs.env }} environment."
+                mrkdown_in:
+                  - text

--- a/.github/workflows/release-gf.yml
+++ b/.github/workflows/release-gf.yml
@@ -1,7 +1,6 @@
-name: 'Tag and Deploy Site (Greenfield)'
+name: 'Tag and Deploy Site (GF)'
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       deploy:

--- a/.github/workflows/release-gf.yml
+++ b/.github/workflows/release-gf.yml
@@ -17,16 +17,18 @@ on:
 jobs:
   tag_repo:
     name: Tag Repo
+    runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
     uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
     with:
       repo_ref: ${{ inputs.repo_ref }}
     secrets: inherit
   deploy:
+    name: Deploy to Staging
+    runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
     permissions:
       contents: read
       id-token: write
     if: ${{ inputs.deploy }}
-    name: Deploy to Staging
     needs: tag_repo
     uses: ./.github/workflows/deploy-gf.yml
     with:

--- a/.github/workflows/release-gf.yml
+++ b/.github/workflows/release-gf.yml
@@ -1,9 +1,7 @@
 name: 'Tag and Deploy Site (Greenfield)'
 
 on:
-  push:
   workflow_dispatch:
-    push:
     inputs:
       deploy:
         description: 'Also deploy to staging?'

--- a/.github/workflows/release-gf.yml
+++ b/.github/workflows/release-gf.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   tag_repo:
+    permissions:
+      contents: write
     name: Tag Repo
     uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
     with:

--- a/.github/workflows/release-gf.yml
+++ b/.github/workflows/release-gf.yml
@@ -1,6 +1,7 @@
 name: 'Tag and Deploy Site (Greenfield)'
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       deploy:

--- a/.github/workflows/release-gf.yml
+++ b/.github/workflows/release-gf.yml
@@ -22,6 +22,9 @@ jobs:
       repo_ref: ${{ inputs.repo_ref }}
     secrets: inherit
   deploy:
+    permissions:
+      contents: read
+      id-token: write
     if: ${{ inputs.deploy }}
     name: Deploy to Staging
     needs: tag_repo

--- a/.github/workflows/release-gf.yml
+++ b/.github/workflows/release-gf.yml
@@ -1,4 +1,4 @@
-name: 'Tag and Deploy Site (GF)'
+name: 'Tag and Deploy Site (Greenfield)'
 
 on:
   workflow_dispatch:
@@ -17,24 +17,16 @@ on:
 jobs:
   tag_repo:
     name: Tag Repo
-    runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
-    steps:
-      - uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
-        with:
-          repo_ref: ${{ inputs.repo_ref }}
-          secrets: inherit
+    uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
+    with:
+      repo_ref: ${{ inputs.repo_ref }}
+    secrets: inherit
   deploy:
+    if: ${{ inputs.deploy }}
     name: Deploy to Staging
-    runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
-    permissions:
-      contents: read
-      id-token: write
     needs: tag_repo
-    steps:
-      - if: ${{ inputs.deploy }}
-        uses: ./.github/workflows/deploy-gf.yml
-        with:
-          env: staging
-          static_repo_ref: ${{ needs.tag_repo.outputs.tag }}
-          secrets: inherit
-
+    uses: ./.github/workflows/deploy-gf.yml
+    with:
+      target_environment: staging
+      static_repo_ref: ${{ needs.tag_repo.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/release-gf.yml
+++ b/.github/workflows/release-gf.yml
@@ -1,0 +1,32 @@
+name: 'Tag and Deploy Site (Greenfield)'
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Also deploy to staging?'
+        type: boolean
+        default: true
+        required: true
+      repo_ref:
+        description: 'Which branch or tag?'
+        required: true
+        default: 'main'
+        type: 'string'
+
+jobs:
+  tag_repo:
+    name: Tag Repo
+    uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
+    with:
+      repo_ref: ${{ inputs.repo_ref }}
+    secrets: inherit
+  deploy:
+    if: ${{ inputs.deploy }}
+    name: Deploy to Staging
+    needs: tag_repo
+    uses: ./.github/workflows/deploy-gf.yml
+    with:
+      target_environment: staging
+      static_repo_ref: ${{ needs.tag_repo.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/release-gf.yml
+++ b/.github/workflows/release-gf.yml
@@ -18,20 +18,23 @@ jobs:
   tag_repo:
     name: Tag Repo
     runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
-    uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
-    with:
-      repo_ref: ${{ inputs.repo_ref }}
-    secrets: inherit
+    steps:
+      - uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
+        with:
+          repo_ref: ${{ inputs.repo_ref }}
+          secrets: inherit
   deploy:
     name: Deploy to Staging
     runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
     permissions:
       contents: read
       id-token: write
-    if: ${{ inputs.deploy }}
     needs: tag_repo
-    uses: ./.github/workflows/deploy-gf.yml
-    with:
-      env: staging
-      static_repo_ref: ${{ needs.tag_repo.outputs.tag }}
-    secrets: inherit
+    steps:
+      - if: ${{ inputs.deploy }}
+        uses: ./.github/workflows/deploy-gf.yml
+        with:
+          env: staging
+          static_repo_ref: ${{ needs.tag_repo.outputs.tag }}
+          secrets: inherit
+

--- a/.github/workflows/release-gf.yml
+++ b/.github/workflows/release-gf.yml
@@ -27,6 +27,6 @@ jobs:
     needs: tag_repo
     uses: ./.github/workflows/deploy-gf.yml
     with:
-      target_environment: staging
+      env: staging
       static_repo_ref: ${{ needs.tag_repo.outputs.tag }}
     secrets: inherit

--- a/common/docsV1.md
+++ b/common/docsV1.md
@@ -898,6 +898,7 @@ To create the Patient Resource, the JSON file may include additional attributes 
 - First and last name
 - Birth date in YYYY-MM-DD
 - Gender
+  - When sharing data, DPC uses the Patient.gender property to represent the sex of the patient as maintained on record at CMS. When registering a patient to your organization, DPC will require the Patient.gender property to be submitted following the corresponding value set. The input provided may be used by DPC to match and validate the patient against CMS records.
 - Medicare Beneficiary Identifier (MBI)
   - Note: If an existing patient is found with the same MBI, the /patient endpoint will return that same patient and not return a new one.
   - For example:


### PR DESCRIPTION
Add deploy-gf and release-gf workflows.

## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4692

## 🛠 Changes

Added Greenfield version of reply and release workflows.

## ℹ️ Context

We need to be able to deploy the static site in the new GF accounts.

Requires https://github.com/CMSgov/dpc-ops/pull/814

## 🧪 Validation

* Successfully cut new release and tag [r55](https://github.com/CMSgov/dpc-static-site/releases/tag/r55).

* Created a bucket in dev and deployed to it ([successful workflow here](https://github.com/CMSgov/dpc-static-site/actions/runs/15115140880)):

<img width="877" alt="image" src="https://github.com/user-attachments/assets/bc8bf65d-686e-4ee2-a856-85359b544c99" />

