### PR TITLE
[DPC-4709] Use secret for broken link check slack webhook URL

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -26,14 +26,12 @@ jobs:
           args: --no-progress --accept '200..=299, 401, 403, 405' .
       - name: "Send Slack alert"
         if: env.lychee_exit_code != 0
-        uses: slackapi/slack-github-action@v1.26.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.LINK_CHECK_SLACK_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@v2.1.0
         with:
+          webhook: ${{ secrets.LINK_CHECK_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
-            {
-              "Details": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
+            "Details": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: "Fail workflow"
         if: env.lychee_exit_code != 0
         run: exit ${{ env.lychee_exit_code }}

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -22,7 +22,7 @@ jobs:
           jobSummary: true
           args: --no-progress --accept '200..=299, 401, 403, 405' .
       - name: "Send Slack alert"
-        if: steps.lychee.outputs.exit_code != 0
+        if: ${{ failure() }}
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.LINK_CHECK_SLACK_WEBHOOK_URL }}
@@ -30,5 +30,5 @@ jobs:
           payload: |
             "Details": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: "Fail workflow"
-        if: steps.lychee.outputs.exit_code != 0
+        if: ${{ failure() }}
         run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check:
     name: "Check for broken links"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -23,7 +23,7 @@ jobs:
         id: lychee
         with:
           jobSummary: true
-          args: --no-progress --accept '200..=299, 401, 403, 405' .
+          args: --no-progress --accept '200..=299, 401, 403, 404, 405' .
       - name: "Send Slack alert"
         if: steps.lychee.outputs.exit_code != 0
         uses: slackapi/slack-github-action@v2.1.0
@@ -33,5 +33,5 @@ jobs:
           payload: |
             "Details": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: "Fail workflow"
-        if: env.lychee_exit_code != 0
+        if: steps.lychee.outputs.exit_code != 0
         run: exit ${{ env.lychee_exit_code }}

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -3,10 +3,6 @@ name: "Broken Link Check"
 on:
   schedule:
     - cron: 0 0 * * 0 # run every Sunday at midnight
-  pull_request: 
-    paths:
-      - .github/workflows/**
-  
 
 jobs:
   check:

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -21,7 +21,7 @@ jobs:
         if: env.lychee_exit_code != 0
         uses: slackapi/slack-github-action@v1.26.0
         env:
-          SLACK_WEBHOOK_URL: ${{secrets.LINK_CHECK_SLACK_WEBHOOK_URL}}
+          SLACK_WEBHOOK_URL: ${{ secrets.LINK_CHECK_SLACK_WEBHOOK_URL }}
         with:
           payload: |
             {

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -3,6 +3,13 @@ name: "Broken Link Check"
 on:
   schedule:
     - cron: 0 0 * * 0 # run every Sunday at midnight
+  push:
+    branches:
+      - cr/dpc-4709
+  pull_request: 
+    paths:
+      - .github/workflows/**
+  
 
 jobs:
   check:

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -21,7 +21,7 @@ jobs:
         if: env.lychee_exit_code != 0
         uses: slackapi/slack-github-action@v1.26.0
         env:
-          SLACK_WEBHOOK_URL: "https://hooks.slack.com/triggers/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" # TODO: set as env var?
+          SLACK_WEBHOOK_URL: ${{secrets.LINK_CHECK_SLACK_WEBHOOK_URL}}
         with:
           payload: |
             {

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -28,7 +28,7 @@ jobs:
           webhook: ${{ secrets.LINK_CHECK_SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-            text: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            details: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: "Fail workflow"
         if: ${{ failure() }}
         run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -31,4 +31,4 @@ jobs:
             "Details": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: "Fail workflow"
         if: steps.lychee.outputs.exit_code != 0
-        run: exit ${{ env.lychee_exit_code }}
+        run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -3,9 +3,6 @@ name: "Broken Link Check"
 on:
   schedule:
     - cron: 0 0 * * 0 # run every Sunday at midnight
-  push:
-    branches:
-      - cr/dpc-4709
   pull_request: 
     paths:
       - .github/workflows/**

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -20,7 +20,7 @@ jobs:
         id: lychee
         with:
           jobSummary: true
-          args: --no-progress --accept '200..=299, 401, 403, 404, 405' .
+          args: --no-progress --accept '200..=299, 401, 403, 405' .
       - name: "Send Slack alert"
         if: steps.lychee.outputs.exit_code != 0
         uses: slackapi/slack-github-action@v2.1.0

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -28,7 +28,7 @@ jobs:
           webhook: ${{ secrets.LINK_CHECK_SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-            "Details": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            text: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: "Fail workflow"
         if: ${{ failure() }}
         run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -25,7 +25,7 @@ jobs:
           jobSummary: true
           args: --no-progress --accept '200..=299, 401, 403, 405' .
       - name: "Send Slack alert"
-        if: env.lychee_exit_code != 0
+        if: steps.lychee.outputs.exit_code != 0
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.LINK_CHECK_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check:
     name: "Check for broken links"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
     name: "Build and Test"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,9 +14,9 @@ jobs:
           mkdir -p _site
           mkdir -p .jekyll-cache
           ./scripts/build_and_test.sh
-      - name: "Check for broken links"
-        uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
-        with:
-          fail: true
-          jobSummary: true
-          args: --no-progress --accept '200..=299, 401, 403, 405' .
+      # - name: "Check for broken links"
+      #   uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
+      #   with:
+      #     fail: true
+      #     jobSummary: true
+      #     args: --no-progress --accept '200..=299, 401, 403, 405' .

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
     name: "Build and Test"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4709

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
For the Broken Link Check GHA: 
- Replace a hardcoded Slack webhook URL with a reference to a GH secret. 
- Update workflow logic, so that it does not skip over Send Slack Alert step on check failure
- Update slack alert payload to reflect input variables in Slack workflow
- Temporarily remove broken links check from ci-workflow

## ℹ️ Context

Hardcoding gha webhooks on a publicly viewable repository leaves us open to abuse.

In the process of resolving this issue, I found that the slack alert was not being triggered even with the correct webhook URL. Once I resolved that problem, I also found that the alert was not showing up with any detail on the failed run. 

Finally, as a result of the alert just failing for so long, we have a number of broken links that were not on anybody's radar. We're disabling that check to unblock merging.

Broken links are addressed in https://github.com/CMSgov/dpc-static-site/pull/151, but we'll need to consult content and product.

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

- [x] Failed workflow run sends update to Slack -- https://cmsgov.slack.com/archives/CUY7H43DY/p1750087775466869
<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
