### PR TITLE
DPC-4766 Slack broken links message via GitHub app

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -32,4 +32,4 @@ jobs:
               - color: danger
                 fields:
                   - title: Broken link(s) found!
-                    value: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    value: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4766

## 🛠 Changes

Slack message of broken links sent via github slack app instead of webhook

## ℹ️ Context

We would like to unify our slack messaging from gha, as well as allowing use of this webhook by AWS.

## 🧪 Validation

Successful message sent: https://cmsgov.slack.com/archives/CUY7H43DY/p1751046138919719
