### PR TITLE
PLT-1095: Add 2 reviewer requirement to DASG repos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything
+ *  @CMSgov/dpc-dev


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1095

## 🛠 Changes

code owners was added

## ℹ️ Context

moving forward API teams (repos) will require CodeOwner approval configured for PR approvals

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Repo settings updated to require at least 2 approvals before merge and 1 approval coming from a code owner member
