### PR TITLE
remove nav items

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -134,15 +134,6 @@ pilot_nav:
     id: about-the-pilot
   - title: Test the API
     id: test-api
-  - title: Apply for Production Credentials
-    id: apply-for-production
-    subnav:
-      - title: Join the Production
-        id: join-prod-queue
-      - title: Schedule a Demonstration
-        id: demo-dpc
-      - title: Provide Security Certification
-        id: upload-security-cred
   - title: Onboard with DPC
     id: onboard-with-dpc
   - title: Share Your Feedback


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4871

## 🛠 Changes

Obsolete items removed from side nave of pilot page.

## ℹ️ Context

When we updated the pilot page to remove information on how to request prod access, we did not update the side nav.

## 🧪 Validation

Side nav no longer has obsolete items:

### Localhost
<img width="1231" height="1014" alt="localhost" src="https://github.com/user-attachments/assets/3b697b21-9555-4176-8e6f-d49ac5fc00ab" />

### Prod
<img width="1236" height="977" alt="prod" src="https://github.com/user-attachments/assets/c74c982d-eecc-4e4c-91a5-edaef690d104" />

