### PR TITLE
Update deploy workflow so stage bucket doesnt get cleared

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,7 @@ jobs:
             -Dsonar.ci.autoconfig.disabled=true
 
       - name: "Sync _site"
-        run: aws s3 sync _site/ s3://"$TARGET_BUCKET"/ --delete
+        run: aws s3 sync _site/ s3://"$TARGET_BUCKET"/ $(["${{ inputs.target_environment }}" == 'prod'] && echo "--delete")
       - name: Upload html files without suffix with content-language set
         run: |
           for file in _site/*.html; do


### PR DESCRIPTION
## 🎫 Ticket

Related: https://jira.cms.gov/browse/DPC-4882

## 🛠 Changes

Removes `--delete` flag from sync on non-prod deploys

## ℹ️ Context

In order to implement previews, stage deployments can't clear the bucket contents, otherwise the files/paths used for previews will be destroyed

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Copied from BCDA https://github.com/CMSgov/bcda-static-site/blob/legacy-main/.github/workflows/deploy.yml#L94
