### PR TITLE
Update remote GHA to use SHA for versioning

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: "Check for broken links"
         uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
         id: lychee
@@ -20,7 +20,7 @@ jobs:
           args: --no-progress --accept '200..=299, 401, 403, 405' .
       - name: "Send Slack alert"
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -35,7 +35,7 @@ jobs:
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV2.html" 
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/updates.html"
           docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 $TARGETS_TO_SCAN
-      - uses: slackapi/slack-github-action@v2.0.0
+      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         name: Slack Success
         with:
           method: chat.postMessage
@@ -48,7 +48,7 @@ jobs:
                 text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.TARGET_BASE_URL }}`"
                 mrkdown_in:
                   - text
-      - uses: slackapi/slack-github-action@v2.0.0
+      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         name: Slack failure
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: "Build and Test"
         run: |
           mkdir -p _site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: 'CMSgov/dpc-static-site'
           ref: ${{ inputs.static_repo_ref }}
@@ -62,7 +62,7 @@ jobs:
         run: docker run -v ./_site:/dpc-site-static/_site -v ./.jekyll-cache:/dpc-site-static/.jekyll-cache --rm static_site
 
       - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
          aws-region: ${{ vars.AWS_REGION }}
          role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run quality gate scan
         if: ${{ inputs.env == 'sandbox' }}
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         with:
           args:
             -Dsonar.projectKey=bcda-dpc-static-site
@@ -104,7 +104,7 @@ jobs:
           DISTRIBUTION_ID=`aws cloudfront list-distributions --query "DistributionList.Items[].{Id:Id, OriginId: Origins.Items[0].Id}[?OriginId=='$TARGET_BUCKET'].Id" --output text`
           aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'
 
-      - uses: slackapi/slack-github-action@v2.0.0
+      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         name: Slack Success
         with:
           method: chat.postMessage
@@ -118,7 +118,7 @@ jobs:
                 mrkdown_in:
                   - text
 
-      - uses: slackapi/slack-github-action@v2.0.0
+      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         name: Slack failure
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4772

## 🛠 Changes

Update remote GHA to uses SHA hashes instead of version numbers.

## ℹ️ Context

Using hashes is more secure in case the GHA is ever compromised, so we've been making this change across all DPC repos.

## 🧪 Validation

Successfully ran all updated workflows:

Broken link check: https://github.com/CMSgov/dpc-static-site/actions/runs/17869408204
508 Compliance: https://github.com/CMSgov/dpc-static-site/actions/runs/17869576022
CI Workflow: https://github.com/CMSgov/dpc-static-site/actions/runs/17869386888
Deploy (to sandbox): https://github.com/CMSgov/dpc-static-site/actions/runs/17869703165
