### PR TITLE
[DPC-5325] Update GHA workflows to use ARM64 runners

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check:
     name: "Check for broken links"
-    runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-dpc-static-site-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: "Checkout code"
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -17,7 +17,9 @@ on:
 jobs:
   compliance_check:
     name: Compliance Check
-    runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-dpc-static-site${{
+      contains('stage', inputs.target_host) && '-non-prod' || '-prod'
+      }}-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Set Target Base
         id: target-base

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -18,7 +18,7 @@ jobs:
   compliance_check:
     name: Compliance Check
     runs-on: codebuild-dpc-static-site${{
-      contains('https://dpc.cms.gov', inputs.target_host) && '-prod' || '-non-prod'
+      inputs.target_host == 'https://stage.dpc.cms.gov' && '-prod' || '-non-prod'
       }}-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Set Target Base

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -18,7 +18,7 @@ jobs:
   compliance_check:
     name: Compliance Check
     runs-on: codebuild-dpc-static-site${{
-      contains('https://stage.dpc.cms.gov', inputs.target_host) && '-non-prod' || '-prod'
+      contains('https://dpc.cms.gov', inputs.target_host) && '-prod' || '-non-prod'
       }}-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Set Target Base

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -18,7 +18,7 @@ jobs:
   compliance_check:
     name: Compliance Check
     runs-on: codebuild-dpc-static-site${{
-      contains('stage', inputs.target_host) && '-non-prod' || '-prod'
+      contains('https://stage.dpc.cms.gov', inputs.target_host) && '-non-prod' || '-prod'
       }}-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Set Target Base
@@ -36,7 +36,7 @@ jobs:
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV1.html"
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV2.html" 
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/updates.html"
-          docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 $TARGETS_TO_SCAN
+          docker run --init --rm --cap-add=SYS_ADMIN mcp/puppeteer:latest@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 $TARGETS_TO_SCAN
       - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         name: Slack Success
         with:

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -17,9 +17,7 @@ on:
 jobs:
   compliance_check:
     name: Compliance Check
-    runs-on: codebuild-dpc-static-site${{
-      inputs.target_host == 'https://stage.dpc.cms.gov' && '-prod' || '-non-prod'
-      }}-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-dpc-static-site-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Set Target Base
         id: target-base

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -40,6 +40,10 @@ jobs:
             SONAR_HOST_URL=/sonarqube/url
             SONAR_TOKEN=/sonarqube/token
             TARGET_BUCKET=/dpc/sandbox/static_site
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   build:
     name: "Build and Test"
-    runs-on: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-dpc-static-site-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: "Checkout code"
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,11 @@ jobs:
             SONAR_TOKEN=/sonarqube/token
             TARGET_BUCKET=/dpc/${{ env.AWS_ENV }}/static_site
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Run quality gate scan
         if: ${{ inputs.env == 'stage' }}
         uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,9 +35,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-dpc-static-site${{
-      inputs.env == 'prod' && '-prod' || '-non-prod'
-      }}-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-dpc-static-site-prod-${{ github.run_id }}-${{ github.run_attempt }}
     env: # note: "sandbox" env is used for "stage" environment, "prod" is for "prod"
       AWS_ENV: ${{ inputs.env == 'prod' && 'prod' || 'sandbox' }}
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-dpc-static-site-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-dpc-static-site${{
+      inputs.env == 'prod' && '-prod' || '-non-prod'
+      }}-${{ github.run_id }}-${{ github.run_attempt }}
     env: # note: "sandbox" env is used for "stage" environment, "prod" is for "prod"
       AWS_ENV: ${{ inputs.env == 'prod' && 'prod' || 'sandbox' }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
     with:
       repo_ref: ${{ inputs.repo_ref }}
-      runner: codebuild-dpc-static-site-non-prod-${{github.run_id}}-${{github.run_attempt}}
+      runner: codebuild-dpc-static-site-prod-${{github.run_id}}-${{github.run_attempt}}
     secrets: inherit
   deploy:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
     with:
       repo_ref: ${{ inputs.repo_ref }}
-      runner: codebuild-dpc-static-site-${{github.run_id}}-${{github.run_attempt}}
+      runner: codebuild-dpc-static-site-non-prod-${{github.run_id}}-${{github.run_attempt}}
     secrets: inherit
   deploy:
     permissions:

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,8 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt update && \
-    apt install npm && \
+RUN apt install npm && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,8 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt install npm &&
+RUN apt update && \
+    apt install npm && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,8 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt install npm && npm install
+RUN yarn install nodejs &&
+    npm install
 
 COPY ./Gemfile Gemfile
 COPY ./Gemfile.lock Gemfile.lock

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,8 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt-get update &&
-    apt-get install npm &&
+RUN apt install npm &&
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,8 +7,8 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt update && \
-    apt install -y npm && \
+RUN apt-get update && \
+    apt-get install -y npm && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -8,7 +8,7 @@ WORKDIR /dpc-site-static
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
 RUN apt-get update && \
-    apt-get install npm && \
+    apt-get install -y npm && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,8 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt install nodejs && \
+RUN apt update && \
+    apt install nodejs && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM mrxder/jekyll-docker-arm64:latest
+FROM jekyll/builder:4.2.0
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,9 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN npm install
+RUN apt update &&
+    apt install npm &&
+    npm install
 
 COPY ./Gemfile Gemfile
 COPY ./Gemfile.lock Gemfile.lock

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM jekyll/builder:4.2.0
+FROM daverichmond/jekyll:builder-4.2.0
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -8,7 +8,7 @@ WORKDIR /dpc-site-static
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
 RUN apt update && \
-    apt install -y npm nodejs && \
+    apt install -y npm && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -8,7 +8,7 @@ WORKDIR /dpc-site-static
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
 RUN apt update && \
-    apt install -y npm nodejs && \
+    apt install -y nodejs && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -8,7 +8,7 @@ WORKDIR /dpc-site-static
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
 RUN apt update && \
-    apt install -y npm && \
+    apt install -y npm nodejs && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,8 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt install -y npm && \
+RUN apt update && \
+    apt install -y npm && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM jekyll/builder:4.2.0
+FROM mrxder/jekyll-docker-arm64:latest
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM daverichmond/jekyll:builder-4.2.0@sha256:88ec0c4db3136cc746afe59aa5e7d7244a2b279b16041fa4e58e0e56fbb367c2
+FROM mrxder/jekyll-docker-arm64
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static
@@ -7,9 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt update && \
-    apt install npm && \
-    npm install
+RUN npm install
 
 COPY ./Gemfile Gemfile
 COPY ./Gemfile.lock Gemfile.lock

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM mrxder/jekyll-docker-arm64:latest
+FROM travishankins/arm64-jekyll-docker:latest
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static
@@ -7,9 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt-get update && \
-    apt-get install -y npm && \
-    npm install
+RUN npm install
 
 COPY ./Gemfile Gemfile
 COPY ./Gemfile.lock Gemfile.lock

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,8 +7,8 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt update &&
-    apt install npm &&
+RUN apt update && \
+    apt install npm && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -8,7 +8,7 @@ WORKDIR /dpc-site-static
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
 RUN apt update && \
-    apt install -y nodejs && \
+    apt install -y npm nodejs && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM daverichmond/jekyll:builder-4.2.0
+FROM jekyll/builder:4.2.0
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static
@@ -7,7 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN nvm install node && npm install
+RUN npm install
 
 COPY ./Gemfile Gemfile
 COPY ./Gemfile.lock Gemfile.lock

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN npm install
+RUN apt install npm && npm install
 
 COPY ./Gemfile Gemfile
 COPY ./Gemfile.lock Gemfile.lock

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,8 +7,8 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt update &&
-    apt install npm &&
+RUN apt-get update &&
+    apt-get install npm &&
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM travishankins/arm64-jekyll-docker:latest
+FROM bretfisher/jekyll:stable-20260315-2119a31
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM mrxder/jekyll-docker-arm64
+FROM mrxder/jekyll-docker-arm64@latest
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM jekyll/builder:4.2.0
+FROM daverichmond/jekyll:builder-4.2.0-arm64
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN yarn install nodejs &&
+RUN yarn install nodejs && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM daverichmond/jekyll:builder-4.2.0-arm64
+FROM daverichmond/jekyll:builder-4.2.0@sha256:88ec0c4db3136cc746afe59aa5e7d7244a2b279b16041fa4e58e0e56fbb367c2
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM mrxder/jekyll-docker-arm64@latest
+FROM mrxder/jekyll-docker-arm64:latest
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /dpc-site-static

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,9 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN npm install
+RUN apt-get update && \
+    apt-get install npm && \
+    npm install
 
 COPY ./Gemfile Gemfile
 COPY ./Gemfile.lock Gemfile.lock

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -8,7 +8,7 @@ WORKDIR /dpc-site-static
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
 RUN apt update && \
-    apt install nodejs && \
+    apt install npm && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN npm install
+RUN nvm install node && npm install
 
 COPY ./Gemfile Gemfile
 COPY ./Gemfile.lock Gemfile.lock

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -8,7 +8,7 @@ WORKDIR /dpc-site-static
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
 RUN apt update && \
-    apt install npm && \
+    apt install -y npm && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,9 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt-get update && \
-    apt-get install -y npm && \
-    npm install
+RUN npm install
 
 COPY ./Gemfile Gemfile
 COPY ./Gemfile.lock Gemfile.lock

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN yarn install nodejs && \
+RUN apt install nodejs && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -7,7 +7,7 @@ WORKDIR /dpc-site-static
 # separately from other application files
 COPY ./package.json package.json
 COPY ./package-lock.json package-lock.json
-RUN apt install npm && \
+RUN apt install -y npm && \
     npm install
 
 COPY ./Gemfile Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
 end
 
+# Needed for Jekyll
+gem "webrick"
+
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   static_site:
-    platform: linux/arm64
     build:
       context: .
       dockerfile: Dockerfiles/Dockerfile.static_site

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   static_site:
+    platform: linux/arm64
     build:
       context: .
       dockerfile: Dockerfiles/Dockerfile.static_site

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 ${TARGETS_TO_SCAN}
+    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0 ${TARGETS_TO_SCAN}
+    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0@sha256:c1e2bda6d92d400e900e497b743552a670a33631799c0a6478e91096e389bd27 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0 ${TARGETS_TO_SCAN}
+    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN eternalfree/puppeteer:23.11.1-linux-arm64 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN eternalfree/puppeteer:23.11.1-linux-arm64 ${TARGETS_TO_SCAN}
+    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -30,6 +30,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
     docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN mcp/puppeteer:latest@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 ${TARGETS_TO_SCAN}
+    echo "Accessibility scan successful"
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -5,20 +5,22 @@ set -eo pipefail
 docker_cleanup()
 {
     docker compose down --remove-orphans
+    return 0
 }
 
 build() {
     docker compose -f docker-compose.yml build static_site
+    return 0
 }
 
-test() {
+scan() {
     trap docker_cleanup EXIT
     docker compose run --publish 4000:4000 --entrypoint "bundle exec jekyll serve -H 0.0.0.0" --name static_site -d static_site
     sleep 30
     docker logs static_site
     ls
     find _site -type f
-    curl localhost:4000 | grep "Update: what we're working on" || { echo "ERROR: Updates page not found"; exit 1; }
+    curl localhost:4000 | grep "Update: what we're working on" || { echo "ERROR: Updates page not found" >&2; exit 1; }
 
     # Perform accessibility scan
     TARGET_TEST_ENV=http://host.docker.internal:4000
@@ -30,12 +32,13 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
     docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN mcp/puppeteer:latest@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 ${TARGETS_TO_SCAN}
-    echo "Accessibility scan successful"
+    return 0
 }
 
 main() {
     build
-    test
+    scan
+    return 0
 }
 
 main

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN canardconfit/puppeteer-docker:puppeteer-23.10.1-arm64 ${TARGETS_TO_SCAN}
+    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0@sha256:c1e2bda6d92d400e900e497b743552a670a33631799c0a6478e91096e389bd27 ${TARGETS_TO_SCAN}
+    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN mcp/puppeteer:latest@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 ${TARGETS_TO_SCAN}
+    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN mcp/puppeteer:latest@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
+    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN mcp/puppeteer:latest@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0 ${TARGETS_TO_SCAN}
+    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0 ${TARGETS_TO_SCAN}
+    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
+    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
+    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
+    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -29,7 +29,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV1"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/docsV2"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates"
-    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN ghcr.io/puppeteer/puppeteer:24.40.0@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 ${TARGETS_TO_SCAN}
+    docker run --platform linux/arm64 --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN canardconfit/puppeteer-docker:puppeteer-23.10.1-arm64 ${TARGETS_TO_SCAN}
 }
 
 main() {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5325

## 🛠 Changes

Moves GHAs to use ARM64 Codebuild runners and updates images as needed. Also cleans up code smells that were merged in while CI workflow wasn't running on pull requests, including explicit `return 0` statements.

## ℹ️ Context

We're migrating to ARM64 Codebuild runners.

## 🧪 Validation

CI workflow and broken link check passing [here](https://github.com/CMSgov/dpc-static-site/actions/runs/24460213951).
508 compliance check passing [here](https://github.com/CMSgov/dpc-static-site/actions/runs/24460433376).
Deploy successful [here](https://github.com/CMSgov/dpc-static-site/actions/runs/24461711486/job/71477464862).
