### PR TITLE
Me/dpc 5364 bump gha node version

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
       - name: "Check for broken links"
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        uses: lycheeverse/82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
         id: lychee
         with:
           jobSummary: true

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
       - name: "Check for broken links"
-        uses: lycheeverse/82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
+        uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
         id: lychee
         with:
           jobSummary: true

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -13,14 +13,14 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
       - name: "Check for broken links"
-        uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         id: lychee
         with:
           jobSummary: true
           args: --no-progress --accept '200..=299, 401, 403, 405' .
       - name: "Send Slack alert"
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -48,6 +48,7 @@ jobs:
                 text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.TARGET_BASE_URL }}`"
                 mrkdown_in:
                   - text
+            text: "Static site 508 compliance check successful"
       - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack failure
         if: ${{ failure() }}
@@ -62,3 +63,4 @@ jobs:
                 text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.TARGET_BASE_URL }}`"
                 mrkdown_in:
                   - text
+            text: "Static site 508 compliance check failed"

--- a/.github/workflows/check_508_compliance.yml
+++ b/.github/workflows/check_508_compliance.yml
@@ -35,7 +35,7 @@ jobs:
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/docsV2.html" 
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/updates.html"
           docker run --init --rm --cap-add=SYS_ADMIN mcp/puppeteer:latest@sha256:11bacd79778b42ebe041a9e2fc18a8c3500bf1362e5bca5bf2ae9dd011be5847 $TARGETS_TO_SCAN
-      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack Success
         with:
           method: chat.postMessage
@@ -48,7 +48,7 @@ jobs:
                 text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Static Site 508 Compliance> completed against `${{ steps.target-base.outputs.TARGET_BASE_URL }}`"
                 mrkdown_in:
                   - text
-      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack failure
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: 24
       - name: Run quality gate scan
-        uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
+        uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # 7.1.0
         with:
           args:
             -Dsonar.projectKey=bcda-dpc-static-site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Run quality gate scan
         if: ${{ inputs.env == 'stage' }}
-        uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
+        uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # 7.1.0
         with:
           args:
             -Dsonar.projectKey=bcda-dpc-static-site
@@ -103,6 +103,7 @@ jobs:
             -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
             -Dsonar.qualitygate.wait=true
             -Dsonar.ci.autoconfig.disabled=true
+            -Dsonar.branch.target=${{ github.base_ref }}
 
       - name: "Sync _site"
         run: aws s3 sync _site/ s3://"$TARGET_BUCKET"/ $(["${{ inputs.target_environment }}" == 'prod'] && echo "--delete")
@@ -118,7 +119,7 @@ jobs:
           DISTRIBUTION_ID=`aws cloudfront list-distributions --query "DistributionList.Items[].{Id:Id, OriginId: Origins.Items[0].Id}[?OriginId=='$TARGET_BUCKET'].Id" --output text`
           aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'
 
-      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack Success
         with:
           method: chat.postMessage
@@ -131,8 +132,9 @@ jobs:
                 text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }}` deployed to ${{ inputs.env }} environment."
                 mrkdown_in:
                   - text
+            text: "SUCCESS: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }}` deployed to ${{ inputs.env }} environment."
 
-      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack failure
         if: ${{ failure() }}
         with:
@@ -146,3 +148,4 @@ jobs:
                 text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }}` deployed to ${{ inputs.env }} environment."
                 mrkdown_in:
                   - text
+            text: "FAILURE: <${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|static site version> `${{ inputs.static_repo_ref }}` deployed to ${{ inputs.env }} environment."


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5364

## 🛠 Changes

- Bumped GHA to Node24 versions.
- Added `text` to Slack payload to avoid warnings.
- Added `branch.target` to SonarQube to limit review to new code.

## ℹ️ Context

Node 20 is being deprecated for GHA so everything that uses it needs to be bumped to 24.

We were getting warnings from the call to the Slack GHA for not including a `text` field as a fall back for when the more dynamic message couldn't be sent.

SonarQube updated on their end and began surfacing problems in old, unrelated code to the present commit.  Adding a branch target forces it to only examine the diff between the currently submitted code and the main branch.  This was already done in the ci-workflow.

## 🧪 Validation

**broken-link-check**
https://github.com/CMSgov/dpc-static-site/actions/runs/24744129846

**check_508_compliance**
https://github.com/CMSgov/dpc-static-site/actions/runs/24744479689

**deploy**
https://github.com/CMSgov/dpc-static-site/actions/runs/24838213173/job/72704384051

**ci-workflow**
All tests passing on this PR. 🤞 